### PR TITLE
#1 Add a Delete Button to the Color Palate Generated

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
                 <button id="downloadBtn">
                     <i class="fas fa-download"></i> Download
                 </button>
+                <button id="deleteBtn">
+                    <i class="fa-solid fa-trash"></i> Delete
+                </button>
                 <div class="social-share">
                     <button id="shareFacebook" class="fa-brands fa-facebook"></button>
                     <button id="shareTwitter" class="fa-brands fa-twitter"></button>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,7 @@ const colorInput = document.getElementById('colorInput');
         const shareTwitter = document.getElementById('shareTwitter');
         const shareInstagram = document.getElementById('shareInstagram');
         const sharePinterest = document.getElementById('sharePinterest');
+        const deleteBtn = document.getElementById('deleteBtn');
 
         let palettes = [];
 
@@ -92,11 +93,16 @@ const colorInput = document.getElementById('colorInput');
                 saveBtn.innerHTML = '<i class="fas fa-save"></i> Save';
                 saveBtn.addEventListener('click', () => savePalette(palette));
 
+                const deleteBtn = document.createElement('button');
+                deleteBtn.innerHTML = '<i class="fa-solid fa-trash"></i> Delete';
+                deleteBtn.addEventListener('click', () => deletePalette(palette));
+
                 const shareBtn = document.createElement('button');
                 shareBtn.innerHTML = '<i class="fas fa-share-alt"></i> Share';
                 shareBtn.addEventListener('click', () => openSnapshotModal(palette));
 
                 actionsDiv.appendChild(saveBtn);
+                actionsDiv.appendChild(deleteBtn);
                 actionsDiv.appendChild(shareBtn);
 
                 paletteCard.appendChild(colorsDiv);
@@ -122,6 +128,14 @@ const colorInput = document.getElementById('colorInput');
         savedPalettes.push(palette);
         localStorage.setItem('savedPalettes', JSON.stringify(savedPalettes));
         alert('Palette saved successfully!');
+    }
+
+    // Delete palette
+    function deletePalette(selectedPalette) {
+        const savedPalettes = JSON.parse(localStorage.getItem('savedPalettes')) || [];
+        const updatedPalettes = savedPalettes.filter((palette)=>JSON.stringify(palette.colors)!==JSON.stringify(selectedPalette.colors))
+        localStorage.setItem('savedPalettes', JSON.stringify(updatedPalettes));
+        alert('Palette deleted successfully!');
     }
 
     // Open snapshot modal


### PR DESCRIPTION
This PR adds the delete button functionality on generated color palettes as in [issue#1](https://github.com/TheOpenInnovator/ChromaVerse/issues/1)

Sample screenshot is added below:
![ChromaVerse-add-delete-button](https://github.com/user-attachments/assets/1af65bcf-c6c9-4cd2-b02e-66344d0e38a7)

Kindly review my PR and let me know if any changes are required.