### PR TITLE
Implemented the copy palette codes function in share window

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
                 </div>
                 <div class="snapshot-copyPalette-action">
                     <button id="copyToClipboard"><i class="fas fa-link"></i> Copy Codes</button>
-                    <div class="palette-codes">Display color codes of current palette</div>
+                    <div id="copy-palette-codes" class="palette-codes">Display color codes of current palette</div>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,9 @@ const shareFacebook = document.getElementById("shareFacebook");
 const shareTwitter = document.getElementById("shareTwitter");
 const shareInstagram = document.getElementById("shareInstagram");
 const sharePinterest = document.getElementById("sharePinterest");
+const colorCodesDiv = document.getElementById('copy-palette-codes');
+const copyButton = document.getElementById('copyToClipboard');
+
 
 let palettes = [];
 
@@ -75,6 +78,7 @@ function generatePalette() {
 
   palettes.unshift(palette);
   renderPalettes();
+  colorCodesDiv.textContent = colors.join(', ');
 }
 
 // Render palettes
@@ -223,6 +227,7 @@ function openSnapshotModal(palette) {
   shareSnapshotModal.style.display = "flex";
   renderSnapshotCanvas(palette);
 }
+copyButton.addEventListener('click',() => {copyToClipboard(colorCodesDiv.textContent)});
 
 // Render snapshot canvas
 function renderSnapshotCanvas(palette, username) {

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
     --background: #f0f0f0;
     --text: #333333;
     --card-bg: #ffffff;
-    --shadow: rgba(0, 0, 0, 0.1);
+    --shadow: rgba(0, 0, 0, 0.1); 
 }
 
 .dark-mode {
@@ -287,7 +287,7 @@ h1 {
     background-color: var(--card-bg);
     display: flex;
     align-items: center;
-    color: var(--shadow);
+    color:var(--text);
     border-radius: 0.25rem;
     gap: 1rem;
 


### PR DESCRIPTION
PR Description
A clear and concise description of what the PR does.

This PR does the following:

1. Enhances the share functionality by adding a copy codes feature to the share window.
2. Provides user toast notification upon copying the color codes, improving overall interaction.

Related Issues: 
Fixes: https://github.com/TheOpenInnovator/ChromaVerse/issues/12

Changes:
List the detailed changes made in this PR.

1. Implemented a display for the current color codes in the copy codes div.
2. Developed a copyToClipboard function to copy the displayed color codes to the clipboard.

Testing Instructions:
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.

- Pull this branch.
- Navigate to the section where the share palette button is located.
- Click the share palette button.
- Verify that the copy codes div displays the current color codes.
- Click the copyToClipboard button.
- Check for the alert confirming whether the copy action was successful.
- Ensure that the copied color codes are available in your clipboard for pasting.

Checklist
Make sure to check off all the items before submitting. 

- [x]  I have performed a self-review of my code.
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [x]  My changes generate no new warnings.
- [x]  I have tested the copy codes functionality for accuracy and user feedback.
- [x]  I am working on this issue under Hacktoberfest.
<img width="960" alt="Screenshot 2024-10-15 000338" src="https://github.com/user-attachments/assets/d0d2f8cf-768a-441c-b521-9f0299fb14d8">
